### PR TITLE
Fix opt crash in addVectorPasses when TargetMachine is null

### DIFF
--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -1162,7 +1162,8 @@ PassBuilder::buildModuleSimplificationPipeline(OptimizationLevel Level,
 void PassBuilder::addVectorPasses(OptimizationLevel Level,
                                   FunctionPassManager &FPM, bool IsFullLTO) {
   // Disable vector passes on windows.
-  if (TM->getTargetTriple().isOSWindows())
+  // TM may be null when opt is run without a target triple (e.g. empty IR).
+  if (TM && TM->getTargetTriple().isOSWindows())
     return;
 
   FPM.addPass(LoopVectorizePass(


### PR DESCRIPTION
## Summary
- Null-check `TM` in `PassBuilder::addVectorPasses` before calling `getTargetTriple()`, matching the existing Windows guards at the call sites.
- Prevents `opt -passes=default<O1>` from access-violating (0xC0000005) when no target triple / TargetMachine is available (e.g. empty IR input).

Closes #174

## Test plan
- [ ] `echo '' | opt -passes='default<O1>' -disable-output` should exit cleanly instead of crashing
- [ ] With a Windows triple / TargetMachine present, vector passes remain disabled as before
- [ ] With a non-Windows TargetMachine, vector passes still run

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/backengineering/codesmith/llvm-msvc/pr/175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787494795&installation_model_id=9532&pr_number=175&repository=backengineering%2Fllvm-msvc&return_to=https%3A%2F%2Fgithub.com%2Fbackengineering%2Fllvm-msvc%2Fpull%2F175&signature=c0bc26b773e4a2cdbd33c25c67da2e785c6d5cdc6495347180a4987ada2b5113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->